### PR TITLE
Add php-fileinfo, used for MIME types

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -17,6 +17,7 @@ RUN \
         php7-pdo_sqlite=7.2.13-r0 \
         php7-pdo=7.2.13-r0 \
         php7-tokenizer=7.2.13-r0 \
+        php7-fileinfo=7.2.13-r0 \
         php7=7.2.13-r0 \
     \
     && apk add --no-cache --virtual .build-dependencies \


### PR DESCRIPTION
# Proposed Changes

Showing uploaded images currently fails as the MIME type cannot be determined.  Adding library used to resolve this.

## Related Issues

None, so far, was raised on Discord.

fixes #8 