### PR TITLE
:sparkles: Add user config option for upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default for Hass.io_
 
+### Option: `max_upload_size`
+
+Maximum file size for uploads, defaults if not specified to 1Mb. Should be
+specified as an integer, i.e. 2 for 2Mb.
+
 ## Embedding into Home Assistant
 
 It is possible to embed the Grocy interface directly into
@@ -120,10 +125,6 @@ panel_iframe:
     icon: mdi:fridge-outline
     url: http://addres.to.your.hass.io:9192
 ```
-
-## Known issues and limitations
-
-- Lorem ipsum.
 
 ## Changelog & Releases
 

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -53,6 +53,7 @@
       "tasks": "bool"
     },
     "certfile": "str",
-    "keyfile": "str"
+    "keyfile": "str",
+    "max_upload_size": "int?"
   }
 }

--- a/grocy/rootfs/etc/cont-init.d/11-nginx.sh
+++ b/grocy/rootfs/etc/cont-init.d/11-nginx.sh
@@ -16,3 +16,8 @@ if bashio::config.true 'ssl'; then
     sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/nginx.conf
     sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/nginx.conf
 fi
+
+if bashio::config.exists 'max_upload_size'; then
+    sed -i "s#client_max_body_size 1M#client_max_body_size \
+        $(bashio::config 'max_upload_size')M#g" /etc/nginx/nginx.conf
+fi

--- a/grocy/rootfs/etc/nginx/nginx-ssl.conf
+++ b/grocy/rootfs/etc/nginx/nginx-ssl.conf
@@ -11,6 +11,7 @@ http {
     default_type       application/octet-stream;
     sendfile           on;
     keepalive_timeout  65;
+    client_max_body_size 1M;
 
     server {
         server_name hassio.local;

--- a/grocy/rootfs/etc/nginx/nginx.conf
+++ b/grocy/rootfs/etc/nginx/nginx.conf
@@ -11,6 +11,7 @@ http {
     default_type       application/octet-stream;
     sendfile           on;
     keepalive_timeout  65;
+    client_max_body_size 1M;
 
     server {
         server_name hassio.local;


### PR DESCRIPTION
# Proposed Changes

Add the ability for users to configure the max upload file size in the NGINX config.
Item in config.json is an integer.

## Related Issues

https://github.com/hassio-addons/addon-grocy/issues/9

