### PR TITLE
✨ Add icon to show in the sidebar

### DIFF
--- a/grocy/config.json
+++ b/grocy/config.json
@@ -7,6 +7,7 @@
   "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 1337,
+  "panel_icon": "mdi:cart",
   "startup": "system",
   "arch": [
     "aarch64",


### PR DESCRIPTION
# Proposed Changes

Adds the cart-icon for the Ingress panel.
Ofcourse Grocy is much more than groceries but
in my opinion it's better than the default puzzle icon.