### PR TITLE
Change Currency to ISO4217 Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ Is used for setting the language. Choose between:
 
 ### Option: `currency`
 
-Determines the currency as displayed in the Grocy interface.
-Examples:  `$`, `€`, `£` or `EUR`.
+Determines the currency as displayed in the Grocy interface, specified by the
+ISO4217 three digit currency code.
+
+Examples:  `USD`, `CAD`, `GBP` or `EUR`.
 
 ### Option: `features`
 

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -48,7 +48,7 @@
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)?",
     "culture": "match(^(da|de|en|en_GB|es|fr|it|nl|no|pl|ru|sv_SE|ta|tr)$)",
-    "currency": "match([a-zA-Z]{3})",
+    "currency": "match(^[A-Z]{3}$)",
     "features": {
       "batteries": "bool",
       "calendar": "bool",

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -48,7 +48,7 @@
   "schema": {
     "log_level": "match(^(trace|debug|info|notice|warning|error|fatal)$)?",
     "culture": "match(^(da|de|en|en_GB|es|fr|it|nl|no|pl|ru|sv_SE|ta|tr)$)",
-    "currency": "str",
+    "currency": "match([a-zA-Z]{3})",
     "features": {
       "batteries": "bool",
       "calendar": "bool",

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -30,7 +30,7 @@
   },
   "options": {
     "culture": "en",
-    "currency": "$",
+    "currency": "USD",
     "features": {
       "batteries": true,
       "calendar": true,


### PR DESCRIPTION
# Proposed Changes

Change the default currency in config.json to the correct format, update readme, as per changes in https://github.com/grocy/grocy/releases/tag/v2.1.0

## Related Issues

#33


<blockquote><img src="https://avatars0.githubusercontent.com/u/44542094?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/grocy/grocy">grocy/grocy</a></strong></div><div>ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home - grocy/grocy</div></blockquote>