### PR TITLE
:hammer: Attempt to fix 404 on returnTo variable

### DIFF
--- a/grocy/rootfs/etc/cont-init.d/nginx.sh
+++ b/grocy/rootfs/etc/cont-init.d/nginx.sh
@@ -30,3 +30,7 @@ sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 
 ingress_entry=$(bashio::addon.ingress_entry)
 sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/php7/php-fpm.d/ingress.conf
+
+ingress_url=$(bashio::addon.ingress_url)
+sed -i "s#%%ingress_url%%#${ingress_url}#g" \
+    /etc/nginx/servers/ingress.conf

--- a/grocy/rootfs/etc/nginx/servers/ingress.conf
+++ b/grocy/rootfs/etc/nginx/servers/ingress.conf
@@ -1,11 +1,16 @@
 server {
+    rewrite_log on;
     listen %%interface%%:1337 default_server;
 
     include /etc/nginx/includes/server_params.conf;
 
     allow   172.30.32.2;
     deny    all;
+    location ~ \/http.*8123(.*)$ {
+    return 301 $scheme://$host:8123%%ingress_url%%$1;
+    }
 
+    
     location ~ .php$ {
         fastcgi_pass 127.0.0.1:9002;
         fastcgi_read_timeout 900;


### PR DESCRIPTION
# Proposed Changes

Rewrite the returnto URL, this is client side which causes a challenge with Ingress.  This doesn't fully duplicate the current behaviour, as it doesn't pass the Search string back, however it stops the 404's and allows users to continue. 
