### PR TITLE
Fixes permission issues on new installation

### DIFF
--- a/grocy/rootfs/etc/cont-init.d/grocy.sh
+++ b/grocy/rootfs/etc/cont-init.d/grocy.sh
@@ -10,7 +10,7 @@ if ! bashio::fs.directory_exists "/data/grocy"; then
     cp -R /var/www/grocy/data /data/grocy
 
     # Ensure file permissions
-    chown -R nginx:nginx /data/grocy
+    chown -R nginx:nginx /data/
     find /data/grocy -not -perm 0644 -type f -exec chmod 0644 {} \;
     find /data/grocy -not -perm 0755 -type d -exec chmod 0755 {} \;
 fi


### PR DESCRIPTION
# Proposed Changes

> Fixes startup issues on a new installation. This would prevent grocy from being accessible on a fresh install

## Related Issues

> [#43]: Grocy won't start - Failed Opening /var/www/grocy/data/config.php