### PR TITLE
🚑Remove base path variable

### DIFF
--- a/grocy/rootfs/etc/php7/php-fpm.d/ingress.conf
+++ b/grocy/rootfs/etc/php7/php-fpm.d/ingress.conf
@@ -9,5 +9,4 @@ pm.min_spare_servers = 2
 pm.max_spare_servers = 5
 pm.max_requests = 1024
 clear_env = no
-env[GROCY_BASE_PATH] = '/'
 env[GROCY_BASE_URL] = '%%ingress_entry%%'

--- a/grocy/rootfs/etc/php7/php-fpm.d/www.conf
+++ b/grocy/rootfs/etc/php7/php-fpm.d/www.conf
@@ -9,4 +9,3 @@ pm.min_spare_servers = 2
 pm.max_spare_servers = 5
 pm.max_requests = 1024
 clear_env = no
-env[GROCY_BASE_PATH] = '/'


### PR DESCRIPTION
# Proposed Changes

Remove base path variable, as it now appears to default to / and is possibly appended when set.  Currently causes 404's in app after v2.6.1

## Related Issues

None
