### PR TITLE
Update config.json

### DIFF
--- a/grocy/config.json
+++ b/grocy/config.json
@@ -49,7 +49,7 @@
   },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
-    "culture": "list(cs|da|de|en|en_GB|es|fr|hu|it|ja|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|tr|zh_TW)",
+    "culture": "list(cs|da|de|el_GR|en|en_GB|es|fr|hu|it|ja|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|tr|zh_TW)",
     "currency": "match(^[A-Z]{3}$)",
     "entry_page": "list(stock|shoppinglist|recipes|chores|tasks|batteries|equipment|calendar|mealplan)",
     "features": {


### PR DESCRIPTION
add el_GR as option .
See https://github.com/grocy/grocy/tree/master/localization/el_GR

# Proposed Changes

> With the current config settings users are unable to select EL/GR
Localization option link https://github.com/grocy/grocy/tree/master/localization/el_GR

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/