### PR TITLE
Update Grocy addon to 3.0.1

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.5
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.0.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -9,27 +9,28 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \
-        nginx=1.18.0-r1 \
-        php7-fpm=7.3.23-r0 \
-        php7-gd=7.3.23-r0 \
-        php7-json=7.3.23-r0 \
-        php7-mbstring=7.3.23-r0 \
-        php7-opcache=7.3.23-r0 \
-        php7-pdo_sqlite=7.3.23-r0 \
-        php7-pdo=7.3.23-r0 \
-        php7-simplexml=7.3.23-r0 \
-        php7-tokenizer=7.3.23-r0 \
-        php7-fileinfo=7.3.23-r0 \
-        php7=7.3.23-r0 \
+        nginx=1.18.0-r13 \
+        php7-fpm=7.4.14-r0 \
+        php7-gd=7.4.14-r0 \
+        php7-json=7.4.14-r0 \
+        php7-mbstring=7.4.14-r0 \
+        php7-opcache=7.4.14-r0 \
+        php7-pdo_sqlite=7.4.14-r0 \
+        php7-pdo=7.4.14-r0 \
+        php7-simplexml=7.4.14-r0 \
+        php7-tokenizer=7.4.14-r0 \
+        php7-fileinfo=7.4.14-r0 \
+        php7=7.4.14-r0 \
+        php7-ctype=7.4.14-r0 \
     \
     && apk add --no-cache --virtual .build-dependencies \
-        git=2.26.2-r0 \
-        yarn=1.22.4-r0 \
-        composer=1.10.16-r0 \
+        git=2.30.0-r0 \
+        yarn=1.22.10-r0 \
+        composer=2.0.8-r0 \
     \
     && yarn global add modclean \
     \
-    && git clone --branch "v2.7.1" --depth=1 \
+    && git clone --branch "v3.0.1" --depth=1 \
         https://github.com/grocy/grocy.git /var/www/grocy \
     \
     && cd /var/www/grocy \

--- a/grocy/build.json
+++ b/grocy/build.json
@@ -1,9 +1,10 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.5",
-    "amd64": "hassioaddons/base-amd64:8.0.5",
-    "armhf": "hassioaddons/base-armhf:8.0.5",
-    "armv7": "hassioaddons/base-armv7:8.0.5",
-    "i386": "hassioaddons/base-i386:8.0.5"
-  }
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.0.1",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.0.1",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.0.1",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.0.1",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.0.1"
+  },
+  "args": {}
 }


### PR DESCRIPTION
Update base image to 9.0.1

# Proposed Changes

This PR will update Grocy to the current Version 3.0.1
Grocy 3.0.1 requires php 7.4 so I also updated the base image to 9.0.1 which is based on alpine 3.13 having php7.4

There are some breaking changes in the API since version 3.0.0 of Grocy so some third party apps might not work with it anymore. This could be an Issue for people who set their addon to auto update or dont read changelogs.
So just a heads up.

And unlike the other PR this was tested by me and runs successfully at least on amd64
![2021-01-22_10-42-05](https://user-images.githubusercontent.com/6130672/105474713-db5faa00-5c9e-11eb-84b0-06127bbf8344.png)




## Related Issues

-
