### PR TITLE
Fix NGINX waiting for non-activated FPM

### DIFF
--- a/grocy/rootfs/etc/services.d/nginx/run
+++ b/grocy/rootfs/etc/services.d/nginx/run
@@ -5,7 +5,7 @@
 # ==============================================================================
 
 # Wait for PHP-FPM to become available
-bashio::net.wait_for 9001
+bashio::net.wait_for 9002
 
 bashio::log.info "Starting NGinx...."
 


### PR DESCRIPTION
# Proposed Changes

Fixes an issue where NGINX is awaiting FPM to start, however, it await a port that doesn't have to be activated.
