### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/grocy/config.json
+++ b/grocy/config.json
@@ -4,7 +4,6 @@
   "slug": "grocy",
   "description": "ERP beyond your fridge! A groceries & household management solution for your home",
   "url": "https://github.com/hassio-addons/addon-grocy",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "panel_icon": "mdi:cart",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
# Proposed Changes

Remove `webui` configuration option, it is obsolete because this add-on has Ingress support.
