### PR TITLE
Add languages: cs, el_GR, fi, he_IL, ja, ko_KR, zh_CN, zh_TW

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -99,14 +99,20 @@ The private key file to use for SSL.
 
 Is used for setting the language. Choose between:
 
+- `cs` (Czech)
 - `da` (Danish)
 - `de` (German)
+- `el_GR` (Greek - Greece)
 - `en` (English)
 - `en_GB` (English - United Kingdom)
 - `es` (Spanish)
+- `fi` (Finnish)
 - `fr` (French)
+- `he_IL` (Hebrew - Israel)
 - `hu` (Hungarian)
 - `it` (Italian)
+- `ja` (Japanese)
+- `ko_KR` (Korean - South Korea)
 - `nl` (Dutch)
 - `no` (Norwegian)
 - `pl` (Polish)
@@ -117,6 +123,8 @@ Is used for setting the language. Choose between:
 - `sv_SE` (Swedish - Sweden)
 - `ta` (Tamil)
 - `tr` (Turkish)
+- `zh_CN` (Chinese - China)
+- `zh_TW` (Chinese - Taiwan)
 
 ### Option: `currency`
 

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -43,7 +43,7 @@
   },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
-    "culture": "list(cs|da|de|en|en_GB|es|fr|hu|it|ja|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|tr|zh_TW)",
+    "culture": "list(cs|da|de|el_GR|en|en_GB|es|fi|fr|he_IL|hu|it|ja|ko_KR|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|ta|tr|zh_CN|zh_TW)",
     "currency": "match(^[A-Z]{3}$)",
     "entry_page": "list(stock|shoppinglist|recipes|chores|tasks|batteries|equipment|calendar|mealplan)",
     "features": {


### PR DESCRIPTION
# Proposed Changes

Adds support for:

- `cs` (Czech)
- `el_GR` (Greek - Greece)
- `fi` (Finnish)
- `he_IL` (Hebrew - Israel)
- `ja` (Japanese)
- `ko_KR` (Korean - South Korea)
- `zh_CN` (Chinese - China)
- `zh_TW` (Chinese - Taiwan)

## Related Issues

closes #120