### PR TITLE
Add missing php7-ldap and php7-exif packages

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -10,6 +10,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache \
         nginx=1.18.0-r13 \
+        php7-exif=7.4.15-r0 \
         php7-fpm=7.4.15-r0 \
         php7-gd=7.4.15-r0 \
         php7-json=7.4.15-r0 \

--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -13,6 +13,7 @@ RUN \
         php7-fpm=7.4.15-r0 \
         php7-gd=7.4.15-r0 \
         php7-json=7.4.15-r0 \
+        php7-ldap=7.4.15-r0 \
         php7-mbstring=7.4.15-r0 \
         php7-opcache=7.4.15-r0 \
         php7-pdo_sqlite=7.4.15-r0 \


### PR DESCRIPTION
# Proposed Changes

Grocy 3 adds LDAP authentication. This requires php7-ldap module, which is added to the dockerfile in this PR. Also, this PR adds the php7-exif dependency required by Grocy 3 for some functionality.

## Related Issues

This is the PR which adds it to grocy’s own docker container https://github.com/grocy/grocy-docker/pull/114

