### PR TITLE
Implement feature setting stock count opened products against minimum stock amount

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -197,7 +197,6 @@ equal Sunday:
   on the internet based on the product barcode. This is currently not yet
   supported by the add-on.
 
-
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -51,7 +51,7 @@ tweaks:
   stock_location_tracking: true
   stock_price_tracking: true
   stock_produc_freezing: true
-  stock_product_opened_tracking: true
+  stock_count_opened_products_against_minimum_stock_amount: true
 log_level: info
 ssl: false
 certfile: fullchain.pem
@@ -180,6 +180,7 @@ The following sub features can be enabled or disabled:
 - `stock_price_tracking`
 - `stock_product_freezing`
 - `stock_product_opened_tracking`
+- `stock_count_opened_products_against_minimum_stock_amount`
 
 Set it `true` to enable it, `false` otherwise.
 

--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -196,7 +196,9 @@ equal Sunday:
   on the internet based on the product barcode. This is currently not yet
   supported by the add-on.
 
-You should have a look to [Barcode Buddy][barcodebuddy], which provides that functionality with a Android app as a barcode scanner and a comfortable web UI to add the scanned products in Grocy (hosted in a hassio add-on).
+You should have a look to [Barcode Buddy][barcodebuddy], which provides that 
+functionality with a Android app as a barcode scanner and a comfortable web UI
+to add the scanned products in Grocy (hosted in a hassio add-on).
 
 ## Changelog & Releases
 

--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -196,6 +196,8 @@ equal Sunday:
   on the internet based on the product barcode. This is currently not yet
   supported by the add-on.
 
+You should have a look to [Barcode Buddy][barcodebuddy], which provides that functionality with a Android app as a barcode scanner and a comfortable web UI to add the scanned products in Grocy (hosted in a hassio add-on).
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]
@@ -263,6 +265,7 @@ SOFTWARE.
 [frenck]: https://github.com/frenck
 [grocy-demo]: https://demo-en.grocy.info
 [grocy]: https://grocy.info/
+[barcodebuddy]: https://github.com/Forceu/barcodebuddy
 [issue]: https://github.com/hassio-addons/addon-grocy/issues
 [python-packages]: https://pypi.org/
 [reddit]: https://reddit.com/r/homeassistant

--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -50,7 +50,8 @@ tweaks:
   stock_best_before_date_tracking: true
   stock_location_tracking: true
   stock_price_tracking: true
-  stock_produc_freezing: true
+  stock_product_freezing: true
+  stock_product_opened_tracking: true
   stock_count_opened_products_against_minimum_stock_amount: true
 log_level: info
 ssl: false
@@ -196,9 +197,6 @@ equal Sunday:
   on the internet based on the product barcode. This is currently not yet
   supported by the add-on.
 
-You should have a look to [Barcode Buddy][barcodebuddy], which provides that
-functionality with a Android app as a barcode scanner and a comfortable web UI
-to add the scanned products in Grocy (hosted in a hassio add-on).
 
 ## Changelog & Releases
 
@@ -267,7 +265,6 @@ SOFTWARE.
 [frenck]: https://github.com/frenck
 [grocy-demo]: https://demo-en.grocy.info
 [grocy]: https://grocy.info/
-[barcodebuddy]: https://github.com/Forceu/barcodebuddy
 [issue]: https://github.com/hassio-addons/addon-grocy/issues
 [python-packages]: https://pypi.org/
 [reddit]: https://reddit.com/r/homeassistant

--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -196,7 +196,7 @@ equal Sunday:
   on the internet based on the product barcode. This is currently not yet
   supported by the add-on.
 
-You should have a look to [Barcode Buddy][barcodebuddy], which provides that 
+You should have a look to [Barcode Buddy][barcodebuddy], which provides that
 functionality with a Android app as a barcode scanner and a comfortable web UI
 to add the scanned products in Grocy (hosted in a hassio add-on).
 

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -68,7 +68,6 @@
       "stock_product_freezing": "bool",
       "stock_product_opened_tracking": "bool",
       "stock_count_opened_products_against_minimum_stock_amount": "bool"
-
     },
     "ssl": "bool",
     "certfile": "str",

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -35,7 +35,8 @@
       "stock_location_tracking": true,
       "stock_price_tracking": true,
       "stock_product_freezing": true,
-      "stock_product_opened_tracking": true
+      "stock_product_opened_tracking": true,
+      "stock_count_opened_products_against_minimum_stock_amount": true
     },
     "ssl": true,
     "certfile": "fullchain.pem",
@@ -65,7 +66,9 @@
       "stock_location_tracking": "bool",
       "stock_price_tracking": "bool",
       "stock_product_freezing": "bool",
-      "stock_product_opened_tracking": "bool"
+      "stock_product_opened_tracking": "bool",
+      "stock_count_opened_products_against_minimum_stock_amount": "bool"
+
     },
     "ssl": "bool",
     "certfile": "str",

--- a/grocy/rootfs/etc/services.d/php-fpm/run
+++ b/grocy/rootfs/etc/services.d/php-fpm/run
@@ -81,6 +81,10 @@ if bashio::config.false 'tweaks.stock_product_opened_tracking'; then
     export GROCY_FEATURE_FLAG_STOCK_PRODUCT_OPENED_TRACKING=0
 fi
 
+if bashio::config.false 'tweaks.stock_count_opened_products_against_minimum_stock_amount'; then
+    export GROCY_FEATURE_SETTING_STOCK_COUNT_OPENED_PRODUCTS_AGAINST_MINIMUM_STOCK_AMOUNT=0
+fi
+
 GROCY_CULTURE=$(bashio::config "culture")
 GROCY_CURRENCY=$(bashio::config "currency")
 GROCY_ENTRY_PAGE=$(bashio::config 'entry_page')


### PR DESCRIPTION
# Proposed Changes

I started to use Grocy and was wondering, that an opened product is not part of my stock anmore. In example, I set up, that I want 1 bottle ketchup on stock. I opened that bottle in Grocy and it says me to buy a new bottle ketchup. I don't like that logic, so I found that reddit discussion: https://www.reddit.com/r/grocy/comments/g53jfs/opening_product_with_quantity_unit_stock/

I implemented the stock_count_opened_products_against_minimum_stock_amount option, that the user can define how grocy should handle opened products.

I also added the hint to Barcode Buddy, because it is very useful for the addon.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
