### PR TITLE
Add config option to add a base url to grocy

### DIFF
--- a/grocy/config.json
+++ b/grocy/config.json
@@ -39,7 +39,8 @@
     },
     "ssl": true,
     "certfile": "fullchain.pem",
-    "keyfile": "privkey.pem"
+    "keyfile": "privkey.pem",
+    "base_url": ""
   },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
@@ -69,6 +70,7 @@
     },
     "ssl": "bool",
     "certfile": "str",
-    "keyfile": "str"
+    "keyfile": "str",
+    "base_url": "str"
   }
 }

--- a/grocy/rootfs/etc/cont-init.d/php-fpm.sh
+++ b/grocy/rootfs/etc/cont-init.d/php-fpm.sh
@@ -5,10 +5,11 @@
 # ==============================================================================
 
 # Generate Ingress configuration
+base_url="$(bashio::config 'base_url')$(bashio::addon.ingress_entry)"
 bashio::var.json \
     name "ingress" \
     port "^9002" \
-    base "$(bashio::addon.ingress_entry)" \
+    base "$base_url" \
     | tempio \
         -template /etc/php7/templates/php-fpm.gtpl \
         -out /etc/php7/php-fpm.d/ingress.conf


### PR DESCRIPTION
# Proposed Changes

As we've seen in a number of issues, the "returnto" option in URLs currently doesn't work when using ingress, leading to 404s. While this is largely a 'cosmetic' issue, and most data is posted, it does lead to some inconvenience, especially in my experience when following the workflow below:

- Enter purchase menu
- Scan/add new barcode
- Follow option to create new product with barcode prefilled
- After saving product, hit the 404 page
- Product is now created, but the barcode is not associated with it, as that part of the process happens after the purchase page is saved, which can't happen without correct redirect

However I've discovered this issue is solved if you add the base url in php-fpm.sh. Before the following GET request would fail:

> [19/Oct/2019:14:06:39 +1100] 404 192.168.1.1, 172.30.33.11, 172.30.32.1(172.30.32.2) GET /https://XXX.duckdns.orgshoppinglistitem/new?list?createdproduct=Flour HTTP/1.1 (Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36)"

But with the above changes, and specifying the following in the config:

> "base_url": "https://XXX.duckdns.org"

The GET request will not fail, as grocy will be able to correctly handle the relative path.

## Related Issues

As mentioned, there have been a number of issues raised about this, namely #36, #55, #58, #78, and #99
