### PR TITLE
Fix Grocy current relative URL handling brain-damage

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -10,7 +10,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
     apk add --no-cache \
         nginx=1.18.0-r13 \
+        patch=2.7.6-r6 \
+        php7-ctype=7.4.15-r0 \
         php7-exif=7.4.15-r0 \
+        php7-fileinfo=7.4.15-r0 \
         php7-fpm=7.4.15-r0 \
         php7-gd=7.4.15-r0 \
         php7-json=7.4.15-r0 \
@@ -21,9 +24,7 @@ RUN \
         php7-pdo=7.4.15-r0 \
         php7-simplexml=7.4.15-r0 \
         php7-tokenizer=7.4.15-r0 \
-        php7-fileinfo=7.4.15-r0 \
         php7=7.4.15-r0 \
-        php7-ctype=7.4.15-r0 \
     \
     && apk add --no-cache --virtual .build-dependencies \
         git=2.30.2-r0 \

--- a/grocy/rootfs/etc/cont-init.d/grocy.sh
+++ b/grocy/rootfs/etc/cont-init.d/grocy.sh
@@ -23,3 +23,8 @@ fi
 bashio::log.debug 'Symlinking data directory to persistent storage location...'
 rm -f -r /var/www/grocy/data
 ln -s /data/grocy /var/www/grocy/data
+
+# Patch current relative URL handling braindamage
+bashio::log.info "Patching Grocy to fix relative URL handling..."
+cd /var/www/grocy || bashio.exit.nok 'Failed cd'
+patch -p1 < /patches/fix_braindamage.patch || true

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -1,0 +1,13 @@
+diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
+index fceaaa0..bfc76e6 100644
+--- a/views/layout/default.blade.php
++++ b/views/layout/default.blade.php
+@@ -87,7 +87,7 @@
+ 		Grocy.Components = { };
+ 		Grocy.Mode = '{{ GROCY_MODE }}';
+ 		Grocy.BaseUrl = '{{ $U('/') }}';
+-		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
++		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
+ 		Grocy.ActiveNav = '@yield('activeNav', '')';
+ 		Grocy.Culture = '{{ GROCY_LOCALE }}';
+ 		Grocy.Currency = '{{ GROCY_CURRENCY }}';


### PR DESCRIPTION
# Proposed Changes

This PR adds a hot-patch to the add-on, fixing Grocy's brain-damaged handling of current relative URLs.

Fixes #99, #88, #89, #78, #58, #51, #55, #36, #24, #30

Upstream issues:
- https://github.com/grocy/grocy/issues/814
- https://github.com/grocy/grocy/issues/852
- https://github.com/grocy/grocy/issues/661
- https://github.com/grocy/grocy/issues/150
- https://github.com/grocy/grocy/issues/232
- https://github.com/grocy/grocy/issues/219

