### PR TITLE
Added base_url configuration to allow Dialogs to close properly

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -19,6 +19,7 @@ comparison to installing any other Home Assistant add-on.
 
 1. Search for the "Grocy" add-on in the Supervisor add-on store.
 1. Install the "Grocy" add-on.
+1. Set the `base_url` in the configuration to your home assistant URL.
 1. Start the "Grocy" add-on.
 1. Check the logs of the "Grocy" add-on to see if everything went well.
 1. Click on the "OPEN WEB UI" button to get into the interface of Grocy.
@@ -32,6 +33,7 @@ comparison to installing any other Home Assistant add-on.
 Example add-on configuration:
 
 ```yaml
+base_url: http://homeassistant.local:8123
 culture: en
 currency: USD
 entry_page: stock
@@ -60,6 +62,11 @@ keyfile: privkey.pem
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
+
+### Option `base_url`
+The `base_url` contains the URL of your home assistant's installation. This is required for your installation to function properly.
+
+Example: `http://homeassistant.local:8123`
 
 ### Option: `log_level`
 

--- a/grocy/config.json
+++ b/grocy/config.json
@@ -15,6 +15,7 @@
     "80/tcp": "Web interface (Not required for Ingress)"
   },
   "options": {
+    "base_url": "http://homeassistant.local:8123",
     "culture": "en",
     "currency": "USD",
     "entry_page": "stock",
@@ -43,6 +44,7 @@
     "keyfile": "privkey.pem"
   },
   "schema": {
+    "base_url": "str",
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "culture": "list(cs|da|de|el_GR|en|en_GB|es|fi|fr|he_IL|hu|it|ja|ko_KR|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|ta|tr|zh_CN|zh_TW)",
     "currency": "match(^[A-Z]{3}$)",

--- a/grocy/rootfs/etc/cont-init.d/grocy.sh
+++ b/grocy/rootfs/etc/cont-init.d/grocy.sh
@@ -24,7 +24,9 @@ bashio::log.debug 'Symlinking data directory to persistent storage location...'
 rm -f -r /var/www/grocy/data
 ln -s /data/grocy /var/www/grocy/data
 
-# Patch current relative URL handling braindamage
-bashio::log.info "Patching Grocy to fix relative URL handling..."
-cd /var/www/grocy || bashio.exit.nok 'Failed cd'
-patch -p1 < /patches/fix_braindamage.patch || true
+if bashio::var.is_empty "$(bashio::config 'base_url')"; then
+    # Patch current relative URL handling braindamage
+    bashio::log.info "Patching Grocy to fix relative URL handling..."
+    cd /var/www/grocy || bashio.exit.nok 'Failed cd'
+    patch -p1 < /patches/fix_braindamage.patch || true
+fi

--- a/grocy/rootfs/etc/cont-init.d/php-fpm.sh
+++ b/grocy/rootfs/etc/cont-init.d/php-fpm.sh
@@ -5,10 +5,11 @@
 # ==============================================================================
 
 # Generate Ingress configuration
+base_url="$(bashio::config 'base_url')$(bashio::addon.ingress_entry)"
 bashio::var.json \
     name "ingress" \
     port "^9002" \
-    base "$(bashio::addon.ingress_entry)" \
+    base "$base_url" \
     | tempio \
         -template /etc/php7/templates/php-fpm.gtpl \
         -out /etc/php7/php-fpm.d/ingress.conf


### PR DESCRIPTION
Taking the changes from https://github.com/hassio-addons/addon-grocy/pull/154 a step further due to the fact Grocy does still not function properly. I've fully implemented all the changes needed to make Grocy work properly if provided the correct `BASE_URL`. You have to have a full URL in the `GROCY_BASE_URL` as noted here, https://github.com/grocy/grocy/blob/master/config-dist.php#L52.

Before this change you would have `/api/hassio_ingress/<key>/` and would get JS errors trying to submit dialogs. After this change you would then have something like `https://homeassistant.local:8123/api/hassio_ingress/<key>/`. With the full URL there are no JS errors and Grocy functions perfectly.

# Proposed Changes

* Add new `base_url` configuration



I also have read the comments of #154 and saying that ingress doesn't need to know the host isn't exactly true. It does know the host, it's just using `/api/<url>` as a shortcut. By providing this configuration option, it's pushing the correct hostname to Grocy so the JS can function properly as it has no way of pulling the correct hostname on the PHP side.

This will also as you had said make it so internal/external access will not be compatible with each other. Which while a problem, unless Grocy is patched to accept a more dynamic solution then this is the best option for now. This also will not break existing installations if you leave `base_url` blank. It'll work just as before.