### PR TITLE
Hot patch more Grocy Javascript braindamage

### DIFF
--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -5,8 +5,9 @@ index fceaaa0..bfc76e6 100644
 @@ -87,7 +87,7 @@
  		Grocy.Components = { };
  		Grocy.Mode = '{{ GROCY_MODE }}';
- 		Grocy.BaseUrl = '{{ $U('/') }}';
+-		Grocy.BaseUrl = '{{ $U('/') }}';
 -		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
++		Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
 +		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
  		Grocy.ActiveNav = '@yield('activeNav', '')';
  		Grocy.Culture = '{{ GROCY_LOCALE }}';


### PR DESCRIPTION
# Proposed Changes

Grocy wants a hardcoded, full-blown base URL. This is really not helpful, especially if the system can be accessed (potentially) using multiple endpoints (like with Home Assistant).

This PR adds to the existing hotpatch to patch Grocy to just figure it out (instead of putting the burden on the user configuration).

## Related Issues

fixes #199
closes #194
