### PR TITLE
Fix CurrentUrlRelative with ingress and BaseUrl when external

### DIFF
--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -7,8 +7,13 @@ index fceaaa0..bfc76e6 100644
  		Grocy.Mode = '{{ GROCY_MODE }}';
 -		Grocy.BaseUrl = '{{ $U('/') }}';
 -		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
-+		Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
-+		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace((new URL(Grocy.BaseUrl)).pathname, "");
++		if('{{ $U('/') }}'.includes('http')) {
++			Grocy.BaseUrl = '{{ $U('/') }}';
++			Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
++		} else {
++			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
++			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace((new URL(Grocy.BaseUrl)).pathname, "");
++		}
  		Grocy.ActiveNav = '@yield('activeNav', '')';
  		Grocy.Culture = '{{ GROCY_LOCALE }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -8,7 +8,7 @@ index fceaaa0..bfc76e6 100644
 -		Grocy.BaseUrl = '{{ $U('/') }}';
 -		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
 +		Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
-+		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
++		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace((new URL(Grocy.BaseUrl)).pathname, "");
  		Grocy.ActiveNav = '@yield('activeNav', '')';
  		Grocy.Culture = '{{ GROCY_LOCALE }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';


### PR DESCRIPTION
# Proposed Changes

There was an issue with `Grocy.CurrentUrlRelative` where the URL wasn't actually getting replaced, this pops the path out of the BaseUrl so it can be replaced correctly. I have tested this with my install and it stops 404s from occurring when adding products from another screen.

