### PR TITLE
Add mapping option for port 443

### DIFF
--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -17,8 +17,10 @@ map:
   - ssl
 ports:
   80/tcp: null
+  443/tcp: null
 ports_description:
   80/tcp: Web interface (Not required for Ingress)
+  443/tcp: HTTPS Web interface (Not required for Ingress)
 options:
   culture: en
   currency: USD


### PR DESCRIPTION
This allows port 443 of the Grocy container to be accessed externally

# Proposed Changes

> Change in addon config file to allow port 443 of the Grocy container to be mapped to a port on the HA instance

## Related Issues

> https://github.com/hassio-addons/addon-grocy/issues/243

