### PR TITLE
Add missing php8-iconv package

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -16,6 +16,7 @@ RUN \
         php8-fileinfo=8.0.13-r0 \
         php8-fpm=8.0.13-r0 \
         php8-gd=8.0.13-r0 \
+        php8-iconv=8.0.13-r0 \
         php8-intl=8.0.13-r0 \
         php8-ldap=8.0.13-r0 \
         php8-mbstring=8.0.13-r0 \


### PR DESCRIPTION
# Proposed Changes

Grocy now requires iconv php module (among others already in the addon).
This PR adds the missing php8-iconv package installation in the Dockerfile.

## Related Issues

Grocy PR introducing the check: grocy/grocy#1540