### PR TITLE
Allow non-administrator HA users to see Grocy

### DIFF
--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -7,6 +7,7 @@ url: https://github.com/hassio-addons/addon-grocy
 ingress: true
 ingress_stream: true
 panel_icon: mdi:cart
+panel_admin: false
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
# Proposed Changes

Adds [`panel_admin: false`](https://developers.home-assistant.io/docs/add-ons/configuration/#:~:text=with%20this%20option.-,panel_admin,-bool) to `config.yaml` allow non-admin HA users to see/access Grocy.

This would allow non-admin users to see Grocy. I personally use a non-admin "Panel" user on my wall tablets to prevent housemates from accidentally breaking something when messing around and currently the Panel user cannot see or access Grocy without opening the port and going around Ingress. In the future if work is ever done to allow home assistant users to login directly to Grocy using the auth API, this would (I assume) be needed anyway.

## Related Issues

A [Home Assistant frontend issue](https://github.com/home-assistant/frontend/issues/5907#issuecomment-857764069) recommends using `panel_admin` for this purpose. 
