### PR TITLE
Apply location fix only when using Ingress

### DIFF
--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -1,15 +1,16 @@
 diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
-index fceaaa0..bfc76e6 100644
+index 4eb3fb8d..d4e5e007 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
-@@ -87,7 +87,7 @@
- 		Grocy.Components = { };
+@@ -88,7 +88,10 @@
+ 		Grocy.Version = '{{ $version }}';
  		Grocy.Mode = '{{ GROCY_MODE }}';
--		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
+ 		Grocy.BaseUrl = '{{ $U('/') }}';
+		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
 +		if(Grocy.BaseUrl.indexOf('http') != 0 || Grocy.BaseUrl.indexOf('hassio_ingress') >= 0) {
 +			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
++			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
 +		};
-+		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
  		Grocy.ActiveNav = '@yield('activeNav', '')';
  		Grocy.Culture = '{{ GROCY_LOCALE }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';


### PR DESCRIPTION
# Proposed Changes

Another iteration on fixing Ingress/Direct access URL issues.
This patch ensures URL handling only differs when using Ingress, otherwise use the original, somewhat odd, URL handling of Grocy.
