### PR TITLE
⬆️ Update Grocy to v3.2.0

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -110,6 +110,7 @@ The private key file to use for SSL.
 
 Is used for setting the language. Choose between:
 
+- `ca` (Catalan)
 - `cs` (Czech)
 - `da` (Danish)
 - `de` (German)

--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -40,7 +40,7 @@ RUN \
     \
     && yarn global add modclean \
     \
-    && git clone --branch "v3.1.3" --depth=1 \
+    && git clone --branch "v3.2.0" --depth=1 \
         https://github.com/grocy/grocy.git /var/www/grocy \
     \
     && cd /var/www/grocy \

--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -48,7 +48,7 @@ options:
   keyfile: privkey.pem
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
-  culture: list(cs|da|de|el_GR|en|en_GB|es|fi|fr|he_IL|hu|it|ja|ko_KR|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|ta|tr|zh_CN|zh_TW)
+  culture: list(ca|cs|da|de|el_GR|en|en_GB|es|fi|fr|he_IL|hu|it|ja|ko_KR|nl|no|pl|pt_BR|pt_PT|ru|sk_SK|sv_SE|ta|tr|zh_CN|zh_TW)
   currency: match(^[A-Z]{3}$)
   entry_page: list(stock|shoppinglist|recipes|chores|tasks|batteries|equipment|calendar|mealplan)
   features:

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -2,15 +2,14 @@ diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
 index 4eb3fb8d..d4e5e007 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
-@@ -88,7 +88,10 @@
- 		Grocy.Version = '{{ $version }}';
+@@ -88,6 +88,10 @@
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';
-		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
+ 		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
 +		if(Grocy.BaseUrl.indexOf('http') != 0 || Grocy.BaseUrl.indexOf('hassio_ingress') >= 0) {
 +			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
 +			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
 +		};
  		Grocy.ActiveNav = '@yield('activeNav', '')';
- 		Grocy.Culture = '{{ GROCY_LOCALE }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';
+ 		Grocy.CalendarFirstDayOfWeek = '{{ GROCY_CALENDAR_FIRST_DAY_OF_WEEK }}';


### PR DESCRIPTION
# Proposed Changes

Bumped Grocy version to v3.2.0. The addon was tested following the "Local Add-on Testing" in https://developers.home-assistant.io/docs/add-ons/testing/

## Related Issues

- https://github.com/hassio-addons/addon-grocy/pull/280
- closes #282
