### PR TITLE
⬆️ Upgrades Grocy to 3.3.0

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -36,7 +36,7 @@ RUN \
     \
     && yarn global add modclean \
     \
-    && git clone --branch "v3.2.0" --depth=1 \
+    && git clone --branch "v3.3.0" --depth=1 \
         https://github.com/grocy/grocy.git /var/www/grocy \
     \
     && cd /var/www/grocy \


### PR DESCRIPTION
# Proposed Changes

Updated Dockerfile to pull the latest Grocy release tag.

https://github.com/grocy/grocy/releases/tag/v3.3.0


closes #295