### PR TITLE
:ambulance: Fix Grocy startup issues

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -56,9 +56,10 @@ RUN \
     \
     && find /var/www/ -type f -name "*.md" -depth -exec rm -f {} \; \
     && rm -f -r \
-        /tmp/* \
         /etc/nginx \
+        /etc/php8/php-fpm.d/www.conf \
         /root/.composer \
+        /tmp/* \
         /usr/lib/node_modules \
         /usr/local/bin/composer \
         /usr/local/share/.cache \

--- a/grocy/rootfs/etc/cont-init.d/grocy.sh
+++ b/grocy/rootfs/etc/cont-init.d/grocy.sh
@@ -8,11 +8,6 @@ if ! bashio::fs.directory_exists "/data/grocy"; then
 
     # Setup structure
     cp -R /var/www/grocy/data /data/grocy
-
-    # Ensure file permissions
-    chown -R nginx:nginx /data/grocy
-    find /data/grocy -not -perm 0644 -type f -exec chmod 0644 {} \;
-    find /data/grocy -not -perm 0755 -type d -exec chmod 0755 {} \;
 fi
 
 if ! bashio::fs.directory_exists "/data/grocy/viewcache"; then

--- a/grocy/rootfs/etc/fix-attrs.d/01-grocy
+++ b/grocy/rootfs/etc/fix-attrs.d/01-grocy
@@ -1,1 +1,0 @@
-/data/grocy true nginx 0644 0755

--- a/grocy/rootfs/etc/php8/templates/php-fpm.gtpl
+++ b/grocy/rootfs/etc/php8/templates/php-fpm.gtpl
@@ -1,6 +1,6 @@
 [{{ .name }}]
-user = nginx
-group = nginx
+user = root
+group = root
 listen = 127.0.0.1:{{ .port }}
 pm = dynamic
 pm.max_children = 10

--- a/grocy/rootfs/etc/services.d/php-fpm/run
+++ b/grocy/rootfs/etc/services.d/php-fpm/run
@@ -89,4 +89,4 @@ GROCY_CULTURE=$(bashio::config "culture")
 GROCY_CURRENCY=$(bashio::config "currency")
 GROCY_ENTRY_PAGE=$(bashio::config 'entry_page')
 
-exec php-fpm8 --nodaemonize
+exec php-fpm8 -R --nodaemonize


### PR DESCRIPTION
# Proposed Changes

Drop the weird ownership juggle, removing the deprecated fix-attrs in the process.

Also found an additional php-fpm process running, originating from the PHP default config. So this PR saves a little bit of memory too.

## Related Issues

fixes #300
