### PR TITLE
patch: fix error on startup

### DIFF
--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -1,8 +1,8 @@
 diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
-index 4eb3fb8d..d4e5e007 100644
+index 551d2eb0..1ce31f69 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
-@@ -88,6 +88,10 @@
+@@ -94,6 +94,10 @@
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';
  		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
@@ -10,6 +10,6 @@ index 4eb3fb8d..d4e5e007 100644
 +			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
 +			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
 +		};
- 		Grocy.ActiveNav = '@yield('activeNav', '')';
+ 		Grocy.View = '{{ $viewName }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';
- 		Grocy.CalendarFirstDayOfWeek = '{{ GROCY_CALENDAR_FIRST_DAY_OF_WEEK }}';
+ 		Grocy.EnergyUnit = '{{ GROCY_ENERGY_UNIT }}';


### PR DESCRIPTION
# Proposed Changes

I noticed on the ticket 391 that this patch cannot be applied properly on the last version:

    INFO: Patching Grocy to fix relative URL handling...
    patching file views/layout/default.blade.php
    Hunk #1 FAILED at 88.
    1 out of 1 hunk FAILED -- saving rejects to file views/layout/default.blade.php.rej

I simply tried to apply the patch on top of the latest v4.0.3 release and fixed the conflicts. The context has changed in v4.0: `ActiveNav` variable has been replaced by `View` in commit [d16d976d0](https://github.com/grocy/grocy/commit/d16d976d0) ("_Simplified viewjs / active page handling_") in Grocy repo.

## Related Issues

I don't know if this will fix the recent issues that have been reported (391, 392, 395) because I'm not using this addon yet: I was looking at trying it and I wanted to fix this issue first. That's why I didn't "link" this PR to these issues.
