### PR TITLE
Increase PHP memory limit

### DIFF
--- a/grocy/rootfs/etc/php82/conf.d/99-grocy.ini
+++ b/grocy/rootfs/etc/php82/conf.d/99-grocy.ini
@@ -8,3 +8,4 @@ opcache.revalidate_freq=0
 opcache.validate_timestamps=0
 php_admin_value[post_max_size] = 64M
 php_admin_value[upload_max_filesize] = 64M
+memory_limit = 384M


### PR DESCRIPTION
I get a out of memory error when I try to add items to a shopping cart, this fixes it. 

# Proposed Changes

I get an out of memory error when I try to use the Add Item button on the Shopping Cart page. Adding a higher than PHP default memory allocation in the ini file fixes this for me.


# Error log I was getting.


## Error Log

-----------------------------------------------------------
 Add-on: Grocy
 ERP beyond your fridge! A groceries & household management solution for your home
-----------------------------------------------------------
 Add-on version: 0.21.0
 You are running the latest version of this add-on.
 System: Home Assistant OS 12.0  (amd64 / qemux86-64)
 Home Assistant Core: 2024.2.3
 Home Assistant Supervisor: 2024.02.0
-----------------------------------------------------------
 Please, share the above information when looking for help
 or support in, e.g., GitHub, forums or the Discord chat.
-----------------------------------------------------------
s6-rc: info: service base-addon-banner successfully started
s6-rc: info: service fix-attrs: starting
s6-rc: info: service base-addon-log-level: starting
s6-rc: info: service base-addon-log-level successfully started
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init: starting
s6-rc: info: service legacy-cont-init successfully started
s6-rc: info: service init-php-fpm: starting
s6-rc: info: service init-nginx: starting
s6-rc: info: service init-grocy: starting
[11:05:04] INFO: Patching Grocy to fix relative URL handling...
patching file views/layout/default.blade.php
s6-rc: info: service init-grocy successfully started
s6-rc: info: service init-php-fpm successfully started
s6-rc: info: service php-fpm: starting
s6-rc: info: service php-fpm successfully started
[11:05:07] INFO: Starting PHP-FPM...
s6-rc: info: service init-nginx successfully started
s6-rc: info: service nginx: starting
s6-rc: info: service nginx successfully started
s6-rc: info: service legacy-services: starting
s6-rc: info: service legacy-services successfully started
[11:05:23] INFO: Starting NGinx....
2024/02/26 11:15:32 [error] 406#406: *66 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 4096 bytes) in /var/www/grocy/packages/morris/lessql/src/LessQL/Row.php on line 72" while reading response header from upstream, client: 172.30.32.2, server: a0d7b954-grocy, request: "GET /shoppinglist HTTP/1.1", upstream: "fastcgi://127.0.0.1:9002", host: "192.168.86.3:8123", referrer: "http://192.168.86.3:8123/api/hassio_ingress/M9dKdl4JBY4tFPvFcITqhEXITThb0fcnzgezzEWE0us/stockoverview"
2024/02/26 11:15:39 [error] 406#406: *66 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 4096 bytes) in /var/www/grocy/packages/morris/lessql/src/LessQL/Row.php on line 72" while reading response header from upstream, client: 172.30.32.2, server: a0d7b954-grocy, request: "GET /shoppinglist HTTP/1.1", upstream: "fastcgi://127.0.0.1:9002", host: "192.168.86.3:8123", referrer: "http://192.168.86.3:8123/api/hassio_ingress/M9dKdl4JBY4tFPvFcITqhEXITThb0fcnzgezzEWE0us/stockoverview"


## Trying 256M
2024/04/23 09:45:37 [error] 376#376: *23 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 1454080 bytes) in /data/grocy/viewcache/e46b19eab9c9eedb43a91cd9d707cc1e.php on line 10" while reading response header from upstream, client: 172.30.32.2, server: a0d7b954-grocy, request: "GET /shoppinglistitem/new?embedded=&list=1 HTTP/1.1", upstream: "fastcgi://127.0.0.1:9002", host: "192.168.86.3:8123", referrer: "http://192.168.86.3:8123/api/hassio_ingress/M9dKdl4JBY4tFPvFcITqhEXITThb0fcnzgezzEWE0us/shoppinglist"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Increased PHP memory limit to 384MB to enhance performance and handle larger data processing tasks more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->