### PR TITLE
Reverse proxy auth header support

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -197,7 +197,8 @@ equal Sunday:
 - `calendar_first_day_of_week`
 - `meal_plan_first_day_of_week`
 
-To setup an auth header to sign in with an auth proxy, an example is using cloudflare tunnels where it should be "Cf-Access-Authenticated-User-Email"
+The following sub feature can be set to specify an auth header to sign in with an auth proxy, an example is using Cloudflare Tunnels where it should be "Cf-Access-Authenticated-User-Email"
+
 - `reverse_proxy_auth_header`
 
 ### Option: `grocy_ingress_user`

--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -57,6 +57,7 @@ tweaks:
   stock_product_freezing: true
   stock_product_opened_tracking: true
   stock_count_opened_products_against_minimum_stock_amount: true
+  reverse_proxy_auth_header: "Cf-Access-Authenticated-User-Email"
 log_level: info
 ssl: false
 certfile: fullchain.pem
@@ -195,6 +196,9 @@ equal Sunday:
 
 - `calendar_first_day_of_week`
 - `meal_plan_first_day_of_week`
+
+To setup an auth header to sign in with an auth proxy, an example is using cloudflare tunnels where it should be "Cf-Access-Authenticated-User-Email"
+- `reverse_proxy_auth_header`
 
 ### Option: `grocy_ingress_user`
 

--- a/grocy/config.yaml
+++ b/grocy/config.yaml
@@ -69,6 +69,7 @@ schema:
     stock_product_freezing: bool
     stock_product_opened_tracking: bool
     stock_count_opened_products_against_minimum_stock_amount: bool
+    reverse_proxy_auth_header: str?
   ssl: bool
   certfile: str
   keyfile: str

--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/php-fpm/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/php-fpm/run
@@ -82,6 +82,11 @@ if bashio::config.false 'tweaks.stock_product_opened_tracking'; then
     export GROCY_FEATURE_FLAG_STOCK_PRODUCT_OPENED_TRACKING=0
 fi
 
+if bashio::config.has_value 'tweaks.reverse_proxy_auth_header'; then
+    export GROCY_AUTH_CLASS="Grocy\Middleware\ReverseProxyAuthMiddleware"
+    export GROCY_REVERSE_PROXY_AUTH_HEADER=$(bashio::config 'tweaks.reverse_proxy_auth_header')
+fi
+
 if bashio::config.false 'tweaks.stock_count_opened_products_against_minimum_stock_amount'; then
     export GROCY_FEATURE_SETTING_STOCK_COUNT_OPENED_PRODUCTS_AGAINST_MINIMUM_STOCK_AMOUNT=0
 fi

--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/php-fpm/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/php-fpm/run
@@ -84,7 +84,7 @@ fi
 
 if bashio::config.has_value 'tweaks.reverse_proxy_auth_header'; then
     export GROCY_AUTH_CLASS="Grocy\Middleware\ReverseProxyAuthMiddleware"
-    export GROCY_REVERSE_PROXY_AUTH_HEADER=$(bashio::config 'tweaks.reverse_proxy_auth_header')
+    export GROCY_REVERSE_PROXY_AUTH_HEADER="$(bashio::config 'tweaks.reverse_proxy_auth_header')"
 fi
 
 if bashio::config.false 'tweaks.stock_count_opened_products_against_minimum_stock_amount'; then


### PR DESCRIPTION
adding support for setting reverse proxy auth header to support using an auth proxy infront of grocy. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable reverse-proxy authentication header support so users can specify a custom header to integrate external auth providers (e.g., Cloudflare Tunnels).

* **Documentation**
  * Updated configuration docs with the new option, usage details, and an example demonstrating how to enable reverse-proxy header authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->