### PR TITLE
Fix unescaped dot in nginx location regex patterns

### DIFF
--- a/grocy/rootfs/etc/nginx/includes/server_params.conf
+++ b/grocy/rootfs/etc/nginx/includes/server_params.conf
@@ -12,7 +12,7 @@ location / {
     try_files $uri $uri/ /index.php?$query_string;
 }
 
-location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
     expires 365d;
 }
 

--- a/grocy/rootfs/etc/nginx/templates/direct.gtpl
+++ b/grocy/rootfs/etc/nginx/templates/direct.gtpl
@@ -14,7 +14,7 @@ server {
     ssl_certificate_key /ssl/{{ .keyfile }};
     {{ end }}
 
-    location ~ .php$ {
+    location ~ \.php$ {
         fastcgi_pass 127.0.0.1:9001;
         fastcgi_read_timeout 900;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/grocy/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/grocy/rootfs/etc/nginx/templates/ingress.gtpl
@@ -6,7 +6,7 @@ server {
     allow   172.30.32.2;
     deny    all;
 
-    location ~ .php$ {
+    location ~ \.php$ {
         fastcgi_pass 127.0.0.1:9002;
         fastcgi_read_timeout 900;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
# Proposed Changes

Fixes unescaped literal dots in nginx `location` regex patterns across three configuration files. An unescaped `.` in a regex matches any character, not a literal dot, so `.php` would match `xphp`, `aphp`, etc.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected web server routing patterns to accurately distinguish between file types, ensuring static assets and PHP files are handled with proper specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->