### PR TITLE
Fix incorrect bashio function call syntax in init-grocy

### DIFF
--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
@@ -22,5 +22,5 @@ ln -s /data/grocy /var/www/grocy/data
 
 # Patch current relative URL handling braindamage
 bashio::log.info "Patching Grocy to fix relative URL handling..."
-cd /var/www/grocy || bashio.exit.nok 'Failed cd'
+cd /var/www/grocy || bashio::exit.nok 'Failed cd'
 patch -p1 < /patches/fix_braindamage.patch || true


### PR DESCRIPTION
# Proposed Changes

SSIA :)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor maintenance update with no functional changes or user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->