### PR TITLE
Warn about default credentials on first boot

### DIFF
--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
@@ -9,6 +9,9 @@ if ! bashio::fs.directory_exists "/data/grocy"; then
 
     # Setup structure
     cp -R /var/www/grocy/data /data/grocy
+
+    bashio::log.warning "The default login credentials are username: 'admin' password: 'admin'."
+    bashio::log.warning "Please change the password after first login!"
 fi
 
 if ! bashio::fs.directory_exists "/data/grocy/viewcache"; then


### PR DESCRIPTION
# Proposed Changes

Adds a warning log message on the very first startup (when the data directory is being initialized) reminding users to change the default `admin`/`admin` credentials after logging in for the first time.

The warning only fires once (on initial setup) not on every restart.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added warning messages during initial setup to inform users of default login credentials (`admin`/`admin`) and prompt for password change after first login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->