### PR TITLE
Remove deprecated X-XSS-Protection header

### DIFF
--- a/grocy/rootfs/etc/nginx/includes/server_params.conf
+++ b/grocy/rootfs/etc/nginx/includes/server_params.conf
@@ -3,7 +3,6 @@ root            /var/www/grocy/public;
 index           index.php;
 
 add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 
 client_max_body_size 64M;


### PR DESCRIPTION
# Proposed Changes

Removes the `X-XSS-Protection` response header from the nginx configuration. This header is deprecated, Chrome removed support in v92, Firefox never implemented it, and modern browsers rely on Content-Security-Policy instead.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
