### PR TITLE
Move Node.js and npm to build-only dependencies

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -15,8 +15,6 @@ ARG GROCY_VERSION="v4.6.0"
 RUN \
     apk add --no-cache \
         nginx=1.28.3-r0 \
-        nodejs=24.14.1-r0 \
-        npm=11.11.0-r0 \
         patch=2.8-r0 \
         php85-ctype=8.5.5-r0 \
         php85-exif=8.5.5-r0 \
@@ -34,6 +32,8 @@ RUN \
     \
     && apk add --no-cache --virtual .build-dependencies \
         git=2.52.0-r0 \
+        nodejs=24.14.1-r0 \
+        npm=11.11.0-r0 \
         php85-openssl=8.5.5-r0 \
         php85-phar=8.5.5-r0 \
     \


### PR DESCRIPTION
# Proposed Changes

To reduce image size. It is only used during build, not at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image by removing unnecessary runtime dependencies. This reduces the final image size while maintaining full functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->