### PR TITLE
Add missing php85-tokenizer extension

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -30,6 +30,7 @@ RUN \
         php85-pdo_sqlite=8.5.5-r0 \
         php85-pdo=8.5.5-r0 \
         php85-simplexml=8.5.5-r0 \
+        php85-tokenizer=8.5.5-r0 \
         php85=8.5.5-r0 \
     \
     && apk add --no-cache --virtual .build-dependencies \
@@ -42,7 +43,7 @@ RUN \
     \
     && cd /var/www/grocy \
     \
-    && php85 /usr/local/bin/composer install --no-dev --ignore-platform-req=ext-tokenizer \
+    && php85 /usr/local/bin/composer install --no-dev \
     && npm install \
         --no-audit \
         --no-fund \


### PR DESCRIPTION
# Proposed Changes

Adds the `php85-tokenizer` PHP extension to the runtime dependencies and removes the `--ignore-platform-req=ext-tokenizer` workaround from the composer install command.

Grocy performs its own PHP extension checks at startup and fails to start without `tokenizer`. The composer flag was suppressing the build-time check but the runtime check was never satisfied.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
