### PR TITLE
Fix frontend assets not loading after migration from yarn to npm

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -50,6 +50,7 @@ RUN \
         --no-update-notifier \
         --omit=dev \
     \
+    && mv /var/www/grocy/node_modules /var/www/grocy/public/packages \
     && npm cache clean --force \
     && apk del --no-cache --purge .build-dependencies \
     \


### PR DESCRIPTION
# Proposed Changes

Regressions introduced when the addon migrated from `base-nodejs` + `yarn` to `base` + `npm`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to reorganize how frontend dependencies are managed during image construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->