### PR TITLE
Document barcode scanner secure context requirement

### DIFF
--- a/grocy/DOCS.md
+++ b/grocy/DOCS.md
@@ -261,6 +261,13 @@ Set `printers.thermal_printer.enabled` to `true` to enable thermal printing.
   on the internet based on the product barcode. This is currently not yet
   supported by the app.
 
+- The barcode scanner feature requires camera access via the browser.
+  Browsers only allow camera access in a [secure context][secure-context]
+  (HTTPS or localhost). When accessing Grocy via the Home Assistant ingress
+  panel over HTTP, the browser will deny camera access. To use the barcode
+  scanner, enable SSL and access Grocy directly via its port instead of
+  through ingress.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]
@@ -333,4 +340,5 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/app-grocy/issues
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/app-grocy/releases
+[secure-context]: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
 [semver]: https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
# Proposed Changes

Adds a known limitation note explaining why the barcode scanner fails with "getUserMedia is not defined" when accessed via the Home Assistant ingress panel.

Browsers only permit camera access in a secure context (HTTPS or localhost). The HA ingress panel proxies over HTTP, so the browser blocks getUserMedia. Users need to enable SSL and access Grocy directly via its port to use the barcode scanner.

## Related Issues

closes #517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * **Barcode Scanner Camera Access**: Added a known limitation note explaining that the barcode scanner requires secure HTTPS access. When accessing through Home Assistant's HTTP ingress panel, camera access will be denied by the browser. Users should enable SSL and access Grocy directly via its port instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->