### PR TITLE
Keep php85-openssl installed at runtime

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -29,13 +29,13 @@ RUN \
         php85-pdo=8.5.5-r1 \
         php85-simplexml=8.5.5-r1 \
         php85-tokenizer=8.5.5-r1 \
+        php85-openssl=8.5.5-r1 \
         php85=8.5.5-r1 \
     \
     && apk add --no-cache --virtual .build-dependencies \
         git=2.52.0-r0 \
         nodejs=24.14.1-r0 \
         npm=11.11.0-r0 \
-        php85-openssl=8.5.5-r1 \
         php85-phar=8.5.5-r1 \
     \
     && git clone --branch "${GROCY_VERSION}" --depth=1 \


### PR DESCRIPTION
This keeps php85-openssl installed in the runtime image instead of only installing it as a build dependency.

Grocy performs the OpenFoodFacts lookup at runtime over HTTPS, so php85-openssl must remain available after the build dependencies are removed.

So this may address https://github.com/hassio-addons/app-grocy/issues/534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Docker image dependencies to ensure security libraries are available at runtime for improved application stability and SSL/TLS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->