### PR TITLE
Add TZ data to PHP config

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -71,6 +71,9 @@ RUN \
 # Copy root filesystem
 COPY rootfs /
 
+# Set Timezone for PHP runtime 
+RUN printf '[PHP]\ndate.timezone = "${TZ}"\n' > /etc/php85/conf.d/50-tzone.ini
+
 # Build arguments
 ARG BUILD_ARCH
 ARG BUILD_DATE


### PR DESCRIPTION
# Proposed Changes

Writes the TZ environment variable on the PHP config directory as is used by grocy

## Related Issues

Solves the following issues:

https://github.com/hassio-addons/app-grocy/issues/375
https://github.com/hassio-addons/app-grocy/issues/362
https://github.com/hassio-addons/app-grocy/issues/274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the PHP runtime timezone through environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->