### PR TITLE
Fix BaseUrl handling in patch for Grocy

### DIFF
--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -2,6 +2,7 @@ diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
 index 551d2eb0..1ce31f69 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
+-@@ -94,6 +94,10 @@
 +@@ -94,6 +94,9 @@
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -2,8 +2,7 @@ diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
 index 551d2eb0..1ce31f69 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
--@@ -94,6 +94,10 @@
-+@@ -94,6 +94,9 @@
+@@ -94,6 +94,9 @@
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';
  		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -8,7 +8,7 @@ index 551d2eb0..1ce31f69 100644
  		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
 +		if(Grocy.BaseUrl.indexOf('http') != 0 || Grocy.BaseUrl.indexOf('hassio_ingress') >= 0) {
 +			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
-+			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
++			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace((new URL(Grocy.BaseUrl)).pathname, "");
 +		};
  		Grocy.View = '{{ $viewName }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -6,10 +6,9 @@ index 551d2eb0..1ce31f69 100644
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';
  		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
-+		if(Grocy.BaseUrl.indexOf('http') != 0 || Grocy.BaseUrl.indexOf('hassio_ingress') >= 0) {
-+			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
-+			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace((new URL(Grocy.BaseUrl)).pathname, "");
-+		};
++		var grocyBaseUrl = new URL(Grocy.BaseUrl, window.location.origin);
++		Grocy.BaseUrl = grocyBaseUrl.href;
++		Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(grocyBaseUrl.pathname, "");
  		Grocy.View = '{{ $viewName }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';
  		Grocy.EnergyUnit = '{{ GROCY_ENERGY_UNIT }}';

--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -2,7 +2,7 @@ diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
 index 551d2eb0..1ce31f69 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
-@@ -94,6 +94,10 @@
++@@ -94,6 +94,9 @@
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';
  		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");


### PR DESCRIPTION
# Proposed Changes

Fixes the calculation of `Grocy.CurrentUrlRelative` when Grocy is accessed through Home Assistant ingress.

The existing add-on patch makes `Grocy.BaseUrl` absolute and then attempts to remove that absolute URL from `window.location.pathname`. Since `pathname` contains no origin, the replacement never matches.

This leaves the ingress prefix inside `Grocy.CurrentUrlRelative`. When Grocy subsequently passes that value to `U(returnTo)`, the ingress path is added for a second time and the resulting navigation returns:

```text
Method not allowed. Must be one of: OPTIONS
```

The change compares `window.location.pathname` with the pathname portion of `Grocy.BaseUrl` instead:

```diff
- Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
+ Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace((new URL(Grocy.BaseUrl)).pathname, "");
```

## Testing

Tested against a live installation running Grocy add-on 0.25.1 and Grocy 4.6.0.

- A product userfield save using the currently generated return path reproduced the duplicated ingress prefix and exact 405 response.
- The same save using the corrected relative path returned to Stock Overview successfully.
- The product and userfield saves completed successfully in both cases.
- The userfield value was verified afterwards.
- No inventory quantities were changed.

## Related Issues

- Related to #546
- Historical report: #293
- Previously proposed fix: #209

This pull request addresses the duplicated post-save ingress navigation. It does not claim to address every Android/API behaviour described in #546.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base URL normalization across standard and non-standard browser addresses.
  * Corrected relative page URL calculation when the application is accessed through an ingress path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->