### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -24,8 +30,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -43,12 +50,38 @@
       "pinDigests": true
     },
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
     },
     {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": [
+        "alpine_3_24/npm",
+        "alpine_3_24/php85",
+        "alpine_3_24/php85-ctype",
+        "alpine_3_24/php85-exif",
+        "alpine_3_24/php85-fileinfo",
+        "alpine_3_24/php85-fpm",
+        "alpine_3_24/php85-gd",
+        "alpine_3_24/php85-iconv",
+        "alpine_3_24/php85-intl",
+        "alpine_3_24/php85-ldap",
+        "alpine_3_24/php85-mbstring",
+        "alpine_3_24/php85-openssl",
+        "alpine_3_24/php85-pdo",
+        "alpine_3_24/php85-pdo_sqlite",
+        "alpine_3_24/php85-phar",
+        "alpine_3_24/php85-simplexml",
+        "alpine_3_24/php85-tokenizer"
+      ],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
+    },
+    {
       "groupName": "PHP",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchDepNames": ["/alpine.*/php.*/"]
     },


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the org: every `alpine_X_YY/*` lookup comes back `no-result`, so our Alpine pins are no longer updated at all and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run pushes every pin through it.

This applies the same fix already landed on app-ssh in [hassio-addons/app-ssh#1119](https://github.com/hassio-addons/app-ssh/pull/1119), pointing the pins straight at the Alpine CDN directory listings instead.

- Added a `custom.alpine` datasource in `format: "html"`, defaulting to `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/`. The branch is `v3.24`, taken from this repository's existing `depNameTemplate`.
- The Alpine custom manager now uses `custom.alpine` and gains `extractVersionTemplate: "^{{{package}}}-(?<version>\\d.*)\\.apk$"`, which pulls the version out of each `href` in the directory listing. The `\d` anchor is what keeps `php85` from matching `php85-ctype-8.5.9-r0.apk`.
- Both `"matchDatasources": ["repology"]` package rules switched over: the blanket automerge rule and the `PHP` group rule.
- Added one rule listing the pins that live in the Alpine `community` repository, with a `registryUrls` override. Custom datasources use `registryStrategy: "first"`, so extra registry URLs are not hunted and community packages would otherwise never resolve. The list was derived mechanically from this repository's `grocy/Dockerfile` against both APKINDEX files, not copied from app-ssh: `npm` plus all 16 `php85*` packages. The remaining four pins (`git`, `nginx`, `nodejs`, `patch`) are in `main` and use the default registry.

## Verification

`renovate-config-validator` passes. Beyond that, a passing CI build here proves nothing, since this change does not touch the Dockerfile and buildx serves the `apk` layer from cache, so I ran a real local lookup instead:

```
docker run --rm -v "$PWD":/repo -w /repo -e LOG_LEVEL=debug \
  -e RENOVATE_PLATFORM=local -e RENOVATE_DRY_RUN=lookup \
  ghcr.io/renovatebot/renovate:latest renovate
```

Results:

- **21 of 21 pins resolved.** The Dockerfile has 21 pinned Alpine packages and Renovate extracted and resolved all 21, each with a `currentVersion` and `fixedVersion`.
- **Zero lookup failures.** No `Found no results` and no `no-result` anywhere in the log. The only `WARN` is the unrelated "GitHub token is required for some dependencies", from the `grocy/grocy` github-releases lookup in a local run.
- **The community rule applies to exactly the right 17 packages.** Each of them shows `"registryUrl": "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64"` in the lookup output; the four `main` packages correctly do not.
- **No updates found, and that is correct.** Every pin already matches the newest version in the v3.24 APKINDEX. I cross-checked all 21 pins against the `main` and `community` APKINDEX files directly and the dry-run agrees: nothing is stale. No pin in this repository is currently blocking another PR, and no pin is missing from both indexes.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

- [hassio-addons/app-ssh#1119](https://github.com/hassio-addons/app-ssh/pull/1119)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated maintenance for Alpine Linux package updates.
  * Added support for tracking packages from community repositories.
  * Improved version detection and automatic merging for eligible updates.
  * Updated PHP package update grouping for more consistent maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->