### PR TITLE
🐛 Give each PHP-FPM pool its own Grocy view cache

### DIFF
--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
@@ -14,16 +14,26 @@ if ! bashio::fs.directory_exists "/data/grocy"; then
     bashio::log.warning "Please change the password after first login!"
 fi
 
-if ! bashio::fs.directory_exists "/data/grocy/viewcache"; then
-    mkdir -p /data/grocy/viewcache
-    chown nginx:nginx /data/grocy/viewcache
-fi
+# The view cache is keyed by Grocy's configuration hash, and the ingress and
+# direct access pools each get their own folder. Start from a clean slate so
+# folders of previous configurations (e.g. a rotated ingress entry) don't pile up.
+bashio::log.debug 'Clearing the Grocy view cache...'
+rm -f -r /data/grocy/viewcache
+mkdir -p /data/grocy/viewcache
+chown nginx:nginx /data/grocy/viewcache
 
 bashio::log.debug 'Symlinking data directory to persistent storage location...'
 rm -f -r /var/www/grocy/data
 ln -s /data/grocy /var/www/grocy/data
 
-# Patch current relative URL handling braindamage
-bashio::log.info "Patching Grocy to fix relative URL handling..."
+# Patch Grocy braindamage
+bashio::log.info "Patching Grocy..."
 cd /var/www/grocy || bashio::exit.nok 'Failed cd'
-patch -p1 < /patches/fix_braindamage.patch || true
+for patch_file in /patches/*.patch; do
+    if ! patch -p1 < "${patch_file}"; then
+        bashio::log.warning \
+            "Failed to apply patch: ${patch_file}, this is likely caused by" \
+            "a Grocy update. Please report this at" \
+            "https://github.com/hassio-addons/app-grocy/issues"
+    fi
+done

--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
@@ -38,9 +38,13 @@ ln -s /data/grocy /var/www/grocy/data
 bashio::log.info "Patching Grocy..."
 cd /var/www/grocy || bashio::exit.nok 'Failed cd'
 for patch_file in /patches/*.patch; do
-    # Check first, so a patch that only partially applies leaves no trace
-    if patch --batch --dry-run -p1 < "${patch_file}" > /dev/null; then
-        patch --batch -p1 < "${patch_file}"
+    # Check before applying, so a patch that only partially applies leaves no
+    # trace. --forward keeps patch from reverting our own work when this runs
+    # again in a container that was restarted instead of recreated.
+    if patch --forward --dry-run -p1 < "${patch_file}" > /dev/null 2>&1; then
+        patch --forward -p1 < "${patch_file}"
+    elif patch --reverse --dry-run -p1 < "${patch_file}" > /dev/null 2>&1; then
+        bashio::log.debug "Patch was already applied: ${patch_file}"
     else
         bashio::log.warning \
             "Failed to apply patch: ${patch_file}, this is likely caused by" \

--- a/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
+++ b/grocy/rootfs/etc/s6-overlay/s6-rc.d/init-grocy/run
@@ -14,13 +14,21 @@ if ! bashio::fs.directory_exists "/data/grocy"; then
     bashio::log.warning "Please change the password after first login!"
 fi
 
-# The view cache is keyed by Grocy's configuration hash, and the ingress and
-# direct access pools each get their own folder. Start from a clean slate so
-# folders of previous configurations (e.g. a rotated ingress entry) don't pile up.
-bashio::log.debug 'Clearing the Grocy view cache...'
-rm -f -r /data/grocy/viewcache
+# The view cache is keyed by a hash of the Grocy version and the base URL, so
+# the ingress and direct access pools each get their own folder. Only clear it
+# when the Grocy version changed, which is what leaves stale folders behind.
+# Clearing it on every start would make the first request of every pool a
+# redirect to the root, which is exactly what the split cache prevents.
+viewcache_stamp="/data/grocy/.viewcache-version"
+grocy_version=$(sha256sum /var/www/grocy/version.json | cut -d' ' -f1)
+if [[ "$(cat "${viewcache_stamp}" 2>/dev/null)" != "${grocy_version}" ]]; then
+    bashio::log.debug 'Grocy version changed, clearing the view cache...'
+    rm -f -r /data/grocy/viewcache
+fi
+
 mkdir -p /data/grocy/viewcache
 chown nginx:nginx /data/grocy/viewcache
+echo "${grocy_version}" > "${viewcache_stamp}"
 
 bashio::log.debug 'Symlinking data directory to persistent storage location...'
 rm -f -r /var/www/grocy/data
@@ -30,7 +38,10 @@ ln -s /data/grocy /var/www/grocy/data
 bashio::log.info "Patching Grocy..."
 cd /var/www/grocy || bashio::exit.nok 'Failed cd'
 for patch_file in /patches/*.patch; do
-    if ! patch -p1 < "${patch_file}"; then
+    # Check first, so a patch that only partially applies leaves no trace
+    if patch --batch --dry-run -p1 < "${patch_file}" > /dev/null; then
+        patch --batch -p1 < "${patch_file}"
+    else
         bashio::log.warning \
             "Failed to apply patch: ${patch_file}, this is likely caused by" \
             "a Grocy update. Please report this at" \

--- a/grocy/rootfs/patches/fix_viewcache_isolation.patch
+++ b/grocy/rootfs/patches/fix_viewcache_isolation.patch
@@ -1,0 +1,53 @@
+diff --git a/app.php b/app.php
+index 9224796..ce945d4 100644
+--- a/app.php
++++ b/app.php
+@@ -50,17 +50,23 @@ catch (\Grocy\Helpers\EInvalidConfig $ex)
+ 	exit('Invalid setting in config.php: ' . $ex->getMessage());
+ }
+ 
+-// Create data/viewcache folder if it doesn't exist
+-$viewcachePath = GROCY_DATAPATH . '/viewcache';
+-if (!file_exists($viewcachePath))
+-{
+-	mkdir($viewcachePath);
+-}
+-
+ // Empty data/viewcache when and trigger database migrations when:
+ // The version changed (so when an update was done)
+ // GROCY_BASE_URL OR GROCY_BASE_PATH changed
+ $hash = hash('sha256', file_get_contents(__DIR__ . '/version.json') . GROCY_BASE_URL . GROCY_BASE_PATH);
++
++// Create the viewcache folder if it doesn't exist.
++// This add-on serves ingress and direct access from two PHP-FPM pools that have
++// a different GROCY_BASE_URL, so every configuration gets its own cache folder.
++// Sharing one folder makes each pool wipe the other's cache and redirect to the
++// root on every request.
++define('GROCY_VIEWCACHE_PATH', GROCY_DATAPATH . '/viewcache/' . $hash);
++$viewcachePath = GROCY_VIEWCACHE_PATH;
++if (!file_exists($viewcachePath))
++{
++	mkdir($viewcachePath, 0777, true);
++}
++
+ $hashCacheFile = $viewcachePath . "/$hash.txt";
+ if (!file_exists($hashCacheFile))
+ {
+@@ -84,7 +90,7 @@ $app = AppFactory::create();
+ $container = $app->getContainer();
+ $container->set('view', function (Container $container)
+ {
+-	return new SlimBladeView(__DIR__ . '/views', GROCY_DATAPATH . '/viewcache');
++	return new SlimBladeView(__DIR__ . '/views', GROCY_VIEWCACHE_PATH);
+ });
+ 
+ $container->set('UrlManager', function (Container $container)
+@@ -126,7 +132,7 @@ $errorMiddleware->setDefaultErrorHandler(
+ 
+ $app->add(new CorsMiddleware($app->getResponseFactory()));
+ 
+-$app->getRouteCollector()->setCacheFile(GROCY_DATAPATH . '/viewcache/route_cache.php');
++$app->getRouteCollector()->setCacheFile(GROCY_VIEWCACHE_PATH . '/route_cache.php');
+ 
+ ob_clean(); // No response output before here
+ $app->run();


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Fixes #552: the API intermittently returns the Grocy HTML page with HTTP 200 instead of JSON.

## Root cause

`init-php-fpm` generates two PHP-FPM pools. The ingress pool gets `env[GROCY_BASE_URL] = <ingress entry>`; the `www` pool is rendered without `base`, so the `{{ if .base }}` guard leaves it unset and Grocy falls back to its default `BASE_URL = '/'`.

Both pools share one `GROCY_DATAPATH`, and `app.php` runs this on every request, before routing:

```php
$hash = hash('sha256', file_get_contents(__DIR__ . '/version.json') . GROCY_BASE_URL . GROCY_BASE_PATH);
$hashCacheFile = $viewcachePath . "/$hash.txt";
if (!file_exists($hashCacheFile))
{
	EmptyFolder($viewcachePath);
	touch($hashCacheFile);
	opcache_reset();
	header('Location: ' . (new UrlManager(GROCY_BASE_URL))->ConstructUrl('/'));
	exit();
}
```

The two pools hash to different values, so each one sees the other's marker as "the configuration changed", wipes the shared view cache, and redirects to the root. They can never both be warm at the same time.

That explains every symptom in the report:

- **HTTP 200 with `<!DOCTYPE html>`.** The response is really a 302 to `/`, and both HA `rest_command` and `requests` based clients such as grocy-py follow redirects, so the caller ends up with the entry page rendered at 200.
- **An immediate retry always works.** The marker matches again until the other pool flips it back.
- **Every endpoint is affected.** This happens before routing, so `/api/objects/*`, `/api/stock/*`, `/system/config` and the iCal export are all equally exposed.
- **A few percent of calls.** That is simply how often sidebar browsing interleaves with API polling.
- **The "otherwise malformed content" variant.** `EmptyFolder()` also deletes `viewcache/route_cache.php`, which `app.php` registers as Slim's route cache, along with every compiled Blade template, while the other pool may be reading them.

It is not really direct-port specific either. Ingress users get flipped too, they just see the browser land on the entry page now and then instead of a parse error.

## The fix

A new patch, `fix_viewcache_isolation.patch`, keys the view cache directory on the configuration hash that Grocy already computes, so each pool gets its own folder and its own `route_cache.php`. The version-change and base-URL-change behaviour that the hash exists for is preserved: a new hash still means a fresh cache and a redirect to the root so migrations run.

`init-grocy` now clears `/data/grocy/viewcache` on start, so folders belonging to configurations that no longer exist (a Grocy update, or a rotated ingress entry) do not pile up.

While in there, patches are applied in a loop over `/patches/*.patch` and a failure now logs a warning naming the patch instead of being swallowed by `|| true`. A silently failing patch here means this bug quietly comes back on the next Grocy release.

## Testing

Reproduced and verified with two `php85 -S` instances off the add-on image, sharing one data directory, one with the ingress `GROCY_BASE_URL` and one without, which is exactly the shape of the two pools. An API key was inserted into the database so the calls are genuinely authenticated, then five rounds of "one ingress page load, then one direct API call":

Before, on `main`:

```
  round 1: HTTP 200 text/html; charset=UTF-8 43885b
  round 2: HTTP 200 text/html; charset=UTF-8 43885b
  round 3: HTTP 200 text/html; charset=UTF-8 43885b
  round 4: HTTP 200 text/html; charset=UTF-8 43885b
  round 5: HTTP 200 text/html; charset=UTF-8 43885b
```

After, on this branch:

```
  round 1: HTTP 200 application/json 241b
  round 2: HTTP 200 application/json 241b
  round 3: HTTP 200 application/json 241b
  round 4: HTTP 200 application/json 241b
  round 5: HTTP 200 application/json 241b
```

Also confirmed:

- Both patches apply cleanly to Grocy v4.6.0 in a freshly built image.
- The two pools now keep separate cache folders side by side, each with its own `route_cache.php`, where before only one marker file ever existed at a time.
- Without the interleaved ingress traffic the direct pool was already stable, which is why this only ever showed up for people using both access methods.
- Shellcheck is clean on the updated `init-grocy` script.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

- Fixes #552

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache isolation to prevent stale or conflicting views and routes after application updates or configuration changes.
  - View caches are now refreshed only when needed, reducing unnecessary startup work.
  - Cache permissions are corrected automatically for reliable web access.

- **Reliability**
  - Startup now processes all available patches and reports failures with actionable guidance instead of stopping silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->